### PR TITLE
fix: ajuste no campo creditLineLimitType

### DIFF
--- a/f2-cartao-de-credito/get-accounts-creditcardaccountid-limits/get-credit-cards-accounts-creditCardAccountId-limits-24.1.json
+++ b/f2-cartao-de-credito/get-accounts-creditcardaccountid-limits/get-credit-cards-accounts-creditCardAccountId-limits-24.1.json
@@ -1,7 +1,7 @@
 {
     "data": [
         {
-            "creditLineLimitType": "CREDITO_A_VISTA",
+            "creditLineLimitType": "LIMITE_CREDITO_TOTAL",
             "consolidationType": "CONSOLIDADO",
             "identificationNumber": "5500",
             "lineName": "CREDITO_A_VISTA",
@@ -14,10 +14,10 @@
             "availableAmount": 21113.0069
         },
         {
-            "creditLineLimitType": "CREDITO_PARCELADO",
+            "creditLineLimitType": "LIMITE_CREDITO_TOTAL",
             "consolidationType": "CONSOLIDADO",
             "identificationNumber": "5500",
-            "lineName": "CREDITO_A_VISTA",
+            "lineName": "CREDITO_PARCELADO",
             "isLimitFlexible": true,
             "limitAmountCurrency": "BRL",
             "limitAmount": 1200000.0000,
@@ -27,10 +27,10 @@
             "availableAmount": 1200000.0000
         },
         {
-            "creditLineLimitType": "SAQUE_CREDITO_BRASIL",
+            "creditLineLimitType": "LIMITE_CREDITO_MODALIDADE_OPERACAO",
             "consolidationType": "CONSOLIDADO",
             "identificationNumber": "5500",
-            "lineName": "CREDITO_A_VISTA",
+            "lineName": "SAQUE_CREDITO_BRASIL",
             "isLimitFlexible": true,
             "limitAmountCurrency": "BRL",
             "limitAmount": 3000.0000,
@@ -40,10 +40,10 @@
             "availableAmount": 3000.0000
         },
         {
-            "creditLineLimitType": "EMPRESTIMO_CARTAO_CONSIGNADO",
+            "creditLineLimitType": "LIMITE_CREDITO_MODALIDADE_OPERACAO",
             "consolidationType": "CONSOLIDADO",
             "identificationNumber": "5500",
-            "lineName": "CREDITO_A_VISTA",
+            "lineName": "EMPRESTIMO_CARTAO_CONSIGNADO",
             "isLimitFlexible": true,
             "limitAmountCurrency": "BRL",
             "limitAmount": 23000.0000,
@@ -53,10 +53,10 @@
             "availableAmount": 22970.0000
         },
         {
-            "creditLineLimitType": "OUTROS",
+            "creditLineLimitType": "LIMITE_CREDITO_MODALIDADE_OPERACAO",
             "consolidationType": "CONSOLIDADO",
             "identificationNumber": "5500",
-            "lineName": "CREDITO_A_VISTA",
+            "lineName": "OUTROS",
             "lineNameAdditionalInfo": "SAQUE BANCOS 24 HORAS",
             "isLimitFlexible": true,
             "limitAmountCurrency": "BRL",
@@ -66,7 +66,7 @@
             "availableAmountCurrency": "BRL",
             "availableAmount": 970.0000
         }
-        
+
     ],
     "links": {
         "self": "https://api.caixa.gov.br/open-banking/credit-cards-accounts/v1/accounts/5cd65564-db2c-11eb-8d19-0242ac130003/limits"

--- a/f2-cartao-de-credito/get-accounts-creditcardaccountid-limits/get-credit-cards-accounts-creditCardAccountId-limits-24.2.json
+++ b/f2-cartao-de-credito/get-accounts-creditcardaccountid-limits/get-credit-cards-accounts-creditCardAccountId-limits-24.2.json
@@ -1,7 +1,7 @@
 {
     "data": [
         {
-            "creditLineLimitType": "CREDITO_A_VISTA",
+            "creditLineLimitType": "LIMITE_CREDITO_TOTAL",
             "consolidationType": "CONSOLIDADO",
             "identificationNumber": "8921",
             "lineName": "CREDITO_A_VISTA",
@@ -14,10 +14,10 @@
             "availableAmount": 0.0000
         },
         {
-            "creditLineLimitType": "CREDITO_PARCELADO",
+            "creditLineLimitType": "LIMITE_CREDITO_TOTAL",
             "consolidationType": "CONSOLIDADO",
             "identificationNumber": "8921",
-            "lineName": "CREDITO_A_VISTA",
+            "lineName": "CREDITO_PARCELADO",
             "isLimitFlexible": true,
             "limitAmountCurrency": "BRL",
             "limitAmount": 1200000.0000,
@@ -26,7 +26,7 @@
             "availableAmountCurrency": "BRL",
             "availableAmount": 550000.0000
         }
-        
+
     ],
     "links": {
         "self": "https://api.caixa.gov.br/open-banking/credit-cards-accounts/v1/accounts/91dc56be-db54-11eb-8d19-0242ac130003/limits"


### PR DESCRIPTION
- Em algumas massas de dados, o campo `creditLineLimitType` (na entidade de limites de cartões de crédito) estava com o valor errado, com o valor do enum do campo `lineName`.
- Vendo o enum no [swagger de cartões de crédito](https://openbanking-brasil.github.io/areadesenvolvedor/swagger/swagger_credit_cards_apis.yaml), os valores aceitos são `LIMITE_CREDITO_TOTAL` e `LIMITE_CREDITO_MODALIDADE_OPERACAO`:
![image](https://user-images.githubusercontent.com/7424022/155343592-6b668f10-bbdd-447f-b2d2-4b6ea11f9bb8.png)
- O `creditLineLimitType` estava sendo preenchido com valores como `CREDITO_A_VISTA` e  `SAQUE_CREDITO_BRASIL`, pertencentes ao enum do `lineName`:
![image](https://user-images.githubusercontent.com/7424022/155344063-66cf5a7a-36ff-45f0-a476-eea080c293bb.png)